### PR TITLE
fix(template): change where the Gruntfile to looks for the bower.json file

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -176,7 +176,7 @@ module.exports = function (grunt) {
     // Automatically inject Bower components into the app
     wiredep: {
       options: {
-        cwd: '<%%= yeoman.app %>'
+        cwd: ''
       },
       app: {
         src: ['<%%= yeoman.app %>/index.html'],


### PR DESCRIPTION
The bower.json file now seems to go into the project root instead of the
app directory. Change the wiredep:options directory to the project root.

closes #8
