### PR TITLE
removed wrong cwd path in wiredep task

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -175,9 +175,6 @@ module.exports = function (grunt) {
 
     // Automatically inject Bower components into the app
     wiredep: {
-      options: {
-        cwd: '<%%= yeoman.app %>'
-      },
       app: {
         src: ['<%%= yeoman.app %>/index.html'],
         ignorePath:  /\.\.\//


### PR DESCRIPTION
Specifying a `cwd` option in a task's config makes that directory the "base" directory from which all the operations start.  
In this case, having the `cwd` pointing to the _app_ folder, and simultaneously having _app_ in the filepaths of the subtasks, the `wiredep` was actually doubling the _app_ folder, searching for files at wrong paths (like _app/app/file-name_).  
I propose this filechange in order to fix the bug and keeping this repo somewhat in sync with [the original one](https://github.com/yeoman/generator-angular/blob/master/templates/common/root/_Gruntfile.js#L177).
