### PR TITLE
Changed confirm password required attr to ng-required

### DIFF
--- a/templates/common/app/views/login.html
+++ b/templates/common/app/views/login.html
@@ -29,7 +29,7 @@
   </p>
   <p class="form-group" ng-cloak ng-show="createMode">
     <label for="loginConfirm">confirm pass</label>
-    <input id="loginConfirm" required name="confirm" type="password" ng-model="confirm"<%= formCtrl %> />
+    <input id="loginConfirm" ng-required="createMode" name="confirm" type="password" ng-model="confirm"<%= formCtrl %> />
   </p>
 
   <p>


### PR DESCRIPTION
This is to avoid browser errors related to hidden required fields:
http://stackoverflow.com/questions/22148080/an-invalid-form-control-with-name-is-not-focusable
